### PR TITLE
Add new theme options to Candela theme

### DIFF
--- a/wp-content/plugins/candela-utility/themes/candela/css/lb.css
+++ b/wp-content/plugins/candela-utility/themes/candela/css/lb.css
@@ -1,0 +1,45 @@
+div.im_block {
+	padding: 2% 3%;
+	margin-bottom: 15px;
+	border-radius: 4px;
+}
+
+div.im_block h3:first-child{
+	text-align: center;
+	margin: -2% -3% 15px;
+	color: #ffffff;
+	padding: 15px 0 15px;
+
+}
+
+.im_learning_objectives{
+	background-color: #f7f7f9;
+}
+
+.im_block.im_learning_objectives h3{
+	background-color: #111111;
+}
+
+.im_key_takeaways{
+	background-color: #eaf5ea;
+}
+
+.im_block.im_key_takeaways h3{
+	background-color: #3a7a33;
+}
+
+.im_exercises{
+	background-color: #e3eff6;
+}
+
+.im_block.im_exercises h3{
+	background-color: #0b6396;
+}
+.im_figure {
+	font-size:85%;
+	line-height:1.3em;
+}
+.im_glossdef {
+	display: none; 
+}
+

--- a/wp-content/plugins/candela-utility/themes/candela/css/openstax.css
+++ b/wp-content/plugins/candela-utility/themes/candela/css/openstax.css
@@ -1,0 +1,25 @@
+.cnx-eoc div.exercise {
+	background-color:#eee;
+	margin-bottom: 1.2em;
+}
+.cnx-eoc div.exercise > .title {
+	background-color:#aaa;
+	color:#fff;
+	padding: 1px 5px;
+}
+.cnx-eoc div.exercise .body {
+	margin: 5px;
+}
+div.note {
+	margin: 10px 3em 0;
+}
+div.figure {
+	margin: 20px;
+}
+div.figure div.mediaobject {
+	text-align: center;
+}
+div.figure > div.title, div.figure > div.caption {
+	font-size:85%;
+	line-height:1.3em;
+}

--- a/wp-content/plugins/candela-utility/themes/candela/functions.php
+++ b/wp-content/plugins/candela-utility/themes/candela/functions.php
@@ -12,3 +12,173 @@ function fitzgerald_enqueue_styles() {
 	wp_enqueue_style( 'fitzgerald-fonts', 'http://fonts.googleapis.com/css?family=Crimson+Text:400,400italic,700|Roboto+Condensed:400,300,300italic,400italic' );
 }
 add_action( 'wp_print_styles', 'fitzgerald_enqueue_styles' );
+
+/* ------------------------------------------------------------------------ *
+ * Global Options Tab
+ * ------------------------------------------------------------------------ */
+
+// Global Options Registration
+function candela_theme_options_global_init() {
+
+	$_page = 'pressbooks_theme_options_global';
+	$_option = 'candela_theme_options_global';
+	$_section = 'global_options_section';
+	$defaults = array(
+		'toc_collapse' => 0
+	);
+
+	if ( false == get_option( $_option ) ) {
+		add_option( $_option, $defaults );
+	}
+
+	add_settings_field(
+		'toc_collapse',
+		__( 'Table of Contents', 'candela' ),
+		'candela_theme_toc_collapse_callback',
+		$_page,
+		$_section,
+		array(
+			 __( 'Make Table of Contents Collapsible', 'candela' )
+		)
+	);
+	
+	add_settings_field(
+		'source_based_css',
+		__( 'Load source-based styles', 'candela' ),
+		'candela_theme_source_based_css_callback',
+		$_page,
+		$_section,
+		array(
+			 __( 'OpenStax', 'candela' ),
+			 __( 'Lardbucket', 'candela' )
+		)
+	);
+	
+	add_settings_field(
+		'enable_mathjax',
+		__( 'MathJax', 'candela' ),
+		'candela_theme_mathjax_callback',
+		$_page,
+		$_section,
+		array(
+			 __( 'Enable MathJax', 'candela' )
+		)
+	);
+	
+	register_setting(
+		$_page,
+		$_option,
+		'candela_theme_options_global_sanitize'
+	);
+}
+add_action('admin_init', 'candela_theme_options_global_init');
+
+
+// TOC Options Field Callback
+function candela_theme_toc_collapse_callback( $args ) {
+
+	$options = get_option( 'candela_theme_options_global' );
+	
+	if ( ! isset( $options['toc_collapse'] ) ) {
+		$options['toc_collapse'] = 0;
+	}
+
+	$html = '<input type="checkbox" id="toc_collapse" name="candela_theme_options_global[toc_collapse]" value="1" ' . checked( 1, $options['toc_collapse'], false ) . '/>';
+	$html .= '<label for="toc_collapse"> ' . $args[0] . '</label>';
+	echo $html;
+}
+
+// Source based CSS Field Callback
+function candela_theme_source_based_css_callback( $args ) {
+
+	$options = get_option( 'candela_theme_options_global' );
+	
+	if ( ! isset( $options['source_based_css'] ) ) {
+		$options['source_based_css'] = 0;
+	}
+	$html .= '<input type="checkbox" id="source_based_css_1" name="candela_theme_options_global[source_based_css_1]" value="1" '.checked(1, $options['source_based_css']&1, false) . '/>';
+	$html .= '<label for="source_based_css_1">'.$args[0].'</label><br/>';
+	$html .= '<input type="checkbox" id="source_based_css_2" name="candela_theme_options_global[source_based_css_2]" value="2" '.checked(2, $options['source_based_css']&2, false) . '/>';
+	$html .= '<label for="source_based_css_2">'.$args[1].'</label>';
+	
+	echo $html;
+}
+
+// Mathjax Field Callback
+function candela_theme_mathjax_callback( $args ) {
+
+	$options = get_option( 'candela_theme_options_global' );
+	
+	if ( ! isset( $options['enable_mathjax'] ) ) {
+		$options['enable_mathjax'] = 0;
+	}
+	$html .= '<input type="checkbox" id="enable_mathjax" name="candela_theme_options_global[enable_mathjax]" value="1" '.checked(1, $options['enable_mathjax'], false) . '/>';
+	$html .= '<label for="enable_mathjax">'.$args[0].'</label>';
+	
+	echo $html;
+}
+
+// Global Options Input Sanitization
+function candela_theme_options_global_sanitize( $input ) {
+
+	$options = get_option( 'candela_theme_options_global' );
+
+	if ( ! isset( $input['toc_collapse'] ) || $input['toc_collapse'] != '1' ) {
+		$options['toc_collapse'] = 0;
+	} else {
+		$options['toc_collapse'] = 1;
+	}
+	
+	$options['source_based_css'] = 0;
+	if ( isset( $input['source_based_css_1'] ) && $input['source_based_css_1']=='1' ) {
+		$options['source_based_css'] += 1;
+	} 
+	if ( isset( $input['source_based_css_2'] ) && $input['source_based_css_2']=='2' ) {
+		$options['source_based_css'] += 2;
+	} 
+	
+	if ( ! isset( $input['enable_mathjax'] ) || $input['enable_mathjax'] != '1' ) {
+		$options['enable_mathjax'] = 0;
+	} else {
+		$options['enable_mathjax'] = 1;
+	}
+	return $options;
+}
+
+
+/**
+ * Get any header scripts, based on options
+ *
+ * @return string
+ *
+ */
+function candela_get_header_scripts() {
+	$options = get_option( 'candela_theme_options_global' );
+	if ( @$options['toc_collapse'] ) {
+		wp_enqueue_script(
+			'candela_toc_collapse', 
+			get_stylesheet_directory_uri().'/js/toc_collapse.js',
+			array( 'jquery' ));
+		wp_enqueue_style( 'dashicons' );
+	}
+	if ((@$options['source_based_css']&1)==1) {
+		wp_enqueue_style('candela_openstax_css', 
+			get_stylesheet_directory_uri().'/css/openstax.css');
+		wp_enqueue_script(
+			'candela_openstax_js', 
+			get_stylesheet_directory_uri().'/js/openstax.js',
+			array( 'jquery' ));
+	}
+	if ((@$options['source_based_css']&2)==2) {
+		wp_enqueue_style('candela_lb_css', 
+			get_stylesheet_directory_uri().'/css/lb.css');
+	}
+	if ( @$options['enable_mathjax'] ) {
+		wp_enqueue_script(
+			'candela_enable_mathjax', 
+			'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML');
+	}
+}
+add_action('wp_enqueue_scripts', 'candela_get_header_scripts');
+
+?>

--- a/wp-content/plugins/candela-utility/themes/candela/js/openstax.js
+++ b/wp-content/plugins/candela-utility/themes/candela/js/openstax.js
@@ -1,0 +1,15 @@
+jQuery(function() {
+	jQuery("div.cnx-eoc div.exercise").each(function(i,el) {
+	  jQuery(el).find("div.solution div.body").hide();
+	  jQuery(el).find("div.solution div.title").replaceWith('<a href="#" class="click-toggle-solution">Show Solution</a>');
+	  jQuery(el).find("a.solution-number").contents().unwrap();
+	});
+	jQuery("a.click-toggle-solution").on('click', function(e) {
+	     if (jQuery(this).text()=="Show Solution") {
+		jQuery(this).text("Hide Solution"); jQuery(this).next().show();
+	     } else {
+		jQuery(this).text("Show Solution"); jQuery(this).next().hide();
+	     }
+	     e.preventDefault();
+	});
+});

--- a/wp-content/plugins/candela-utility/themes/candela/js/toc_collapse.js
+++ b/wp-content/plugins/candela-utility/themes/candela/js/toc_collapse.js
@@ -1,0 +1,16 @@
+jQuery(function() {
+	//jQuery("#toc > ul").find("li ul").parent().hide();
+	jQuery("#toc > ul").find("li h4:not(:has(a)):not(:empty)").on('click', function() {
+			jQuery(this).parent().next().slideToggle(100);
+			if (jQuery(this).find(".dashicons").hasClass("dashicons-arrow-up")) {
+				jQuery(this).find(".dashicons").removeClass("dashicons-arrow-up").addClass("dashicons-arrow-down");
+			} else {
+				jQuery(this).find(".dashicons").removeClass("dashicons-arrow-down").addClass("dashicons-arrow-up");
+			}
+		}).css("cursor","pointer")
+		.prepend('<div class="dashicons dashicons-arrow-up" style="float:right"></div>')
+		.parent().next().hide();
+
+	//open up current
+	jQuery("#toc a[href*='"+window.location.pathname+"']").parent().parent().parent().prev().find("h4:not(:has(a))").trigger('click');//show();
+});

--- a/wp-content/plugins/candela-utility/themes/candela/style.css
+++ b/wp-content/plugins/candela-utility/themes/candela/style.css
@@ -71,6 +71,18 @@ ol.alphalist li::before{
 .page-title {
 	font-weight: normal;
 }
+
+#toc h4, #toc li.chapter {
+	padding-left: 10px;
+	text-indent: -10px;
+}
+
+#toc .dashicons {
+	color: #aaa;
+}
+#toc h4:hover .dashicons {
+	color: #777;
+}
 /****************************************
 	Structure
 *****************************************/


### PR DESCRIPTION
Is does the same thing as my earlier pull request, but adds it to the Candela theme rather than the opentextbook theme.  Here's the details again:

This is a set of enhancements to consider at some point. They add three new theme options to the Candela theme:

1) An option to make the pop-out table-of-contents expandable/collapsible by part. Clicking a part title will toggle it open/closed. By default, all parts are closed except for the part containing the current chapter, and any parts with Part Text. This will help make courses with a ton of chapters more manageable to navigate. Also adds an indent after the first line when a chapter title wraps to help differentiate a wrapped line from a new chapter.

2) An option to load source-specific styles, to deal with some display issues with imported content without having to resort to inline styles. So far I have added two:
a) OpenStax: Boxes exercises, and adds JS to make exercise solutions toggle to show. Insets figures and a few other small tweaks.
b) Lardbucket: uses styles identical to the editor bcc-box styles to box some key features. Insets figures and a few other small tweaks.

3) An option to enable MathJax for the book, loaded from the CDN using the most general config: TeX-MML-AM_HTMLorMML