### PR TITLE
Adds the ability to use blog slugs in addition to blog IDs

### DIFF
--- a/wp-content/plugins/candela-lti/candela-lti.php
+++ b/wp-content/plugins/candela-lti/candela-lti.php
@@ -115,7 +115,17 @@ class CandelaLTI {
     }
     // Currently just redirect to the blog/site homepage.
     if ( ! ( empty( $wp->query_vars['blog'] ) ) ){
-      switch_to_blog((int)$wp->query_vars['blog']);
+      if ( !is_numeric( $wp->query_vars['blog'] ) ) {
+         $details = get_blog_details($wp->query_vars['blog']);
+         if ( $details && $details->blog_id ) {
+           switch_to_blog((int)$details->blog_id);
+         } else {
+           wp_redirect( get_site_url( 1 ) );
+           exit;
+         }
+      } else {
+         switch_to_blog((int)$wp->query_vars['blog']);
+      }
       wp_redirect( get_bloginfo('wpurl') . '/table-of-contents' );
       exit;
     }
@@ -281,6 +291,7 @@ class CandelaLTI {
    * Add our LTI resource_link_id mapping api endpoint
    */
   public static function add_rewrite_rule() {
+    add_rewrite_rule( '^api/lti/([a-z][a-z0-9]*)/?$', 'index.php?__lti=1&blog=$matches[1]', 'top');
     add_rewrite_rule( '^api/candelalti?(.*)', 'index.php?__candelalti=1&$matches[1]', 'top');
   }
 

--- a/wp-content/plugins/lti/single-lti_consumer.php
+++ b/wp-content/plugins/lti/single-lti_consumer.php
@@ -28,7 +28,7 @@ get_header(); ?>
           echo ': </label>';
           echo '<strong id="lti_consumer_endpoint" name="lti_consumer_endpoint">' . $endpoint . '</strong>';
           echo '</div>';
-          echo '<div class="description">Replace BLOGID with the site id the user should be redirected to.</div>';
+          echo '<div class="description">Replace BLOGID with the site id or site slug the user should be redirected to.</div>';
 
 		      if ( $key = get_post_meta( get_the_ID(), LTI_META_KEY_NAME, true ) ) {
             echo '<div><label for="lti_consumer_key">';


### PR DESCRIPTION
It is hard to determine what a blog's ID is.  This makes it hard for a user setting up LTI to determine what the proper endpoint for a blog should be.

A simple solution is to allow an LTI endpoint of the form /api/lti/blog-slug, rather than api/lti/blogid.  

This change adds that capability. This should not affect anything else.  Numeric blogids will still work.
