### PR TITLE
Add the ability to specify a page in an LTI launch URL

### DIFF
--- a/wp-content/plugins/lti/lti.php
+++ b/wp-content/plugins/lti/lti.php
@@ -321,7 +321,7 @@ class LTI {
    * Add our LTI api endpoint
    */
   public static function add_rewrite_rule() {
-    add_rewrite_rule( '^api/lti/([0-9]+/?)', 'index.php?__lti=1&blog=$matches[1]', 'top');
+    add_rewrite_rule( '^api/lti/([0-9]+/?)\s*$', 'index.php?__lti=1&blog=$matches[1]', 'top');
   }
 
   /**

--- a/wp-content/plugins/lti/single-lti_consumer.php
+++ b/wp-content/plugins/lti/single-lti_consumer.php
@@ -28,7 +28,7 @@ get_header(); ?>
           echo ': </label>';
           echo '<strong id="lti_consumer_endpoint" name="lti_consumer_endpoint">' . $endpoint . '</strong>';
           echo '</div>';
-          echo '<div class="description">Replace BLOGID with the site id the user should be redirected to.</div>';
+          echo '<div class="description">Replace BLOGID with the site id or site slug the user should be redirected to.</div>';
 
 		      if ( $key = get_post_meta( get_the_ID(), LTI_META_KEY_NAME, true ) ) {
             echo '<div><label for="lti_consumer_key">';


### PR DESCRIPTION
The current system allows associating resource_link_ids with pages by clicking a button on the page after launch.  This will work well in a lot of cases, but not well if an LMS course with LTI links is copied, since all those associations will get lost.

I have some personal use-cases where it makes sense to have perma-link style LTI links, where any copy of the LMS course will still point to the same book and page. For example, where an instructor plans to use the same book over multiple sections, and only wants to have to set things up once.

This change adds the ability to specify in the LTI link the page slug, in the form /api/lti/blog-slug/page-slug

This use case may not be relevant to Lumen, but I figured I'd share the work anyway, just in case it might be useful.  Note: This request also includes the previous LTI_blog_slugs changes.  They were interdependent.
