### PR TITLE
Import Candela license & citations on WRX import

### DIFF
--- a/wp-content/plugins/candela-citation/candela-citation.php
+++ b/wp-content/plugins/candela-citation/candela-citation.php
@@ -28,6 +28,7 @@ class CandelaCitation {
 
     add_action( 'add_meta_boxes', array( __CLASS__, 'add_meta_boxes' ) );
     add_action( 'save_post', array( __CLASS__, 'save') );
+    add_filter( 'pb_import_metakeys', array( __CLASS__, 'get_import_metakeys') );
   }
 
   /**
@@ -308,6 +309,14 @@ class CandelaCitation {
     }
 
     return $result;
+  }
+  
+  /**
+   * Add Candela Citation to to-import meta 
+   */
+  public static function get_import_metakeys( $fields ) {
+  	$fields[] = CANDELA_CITATION_FIELD; 
+  	return $fields; 
   }
 
   /**

--- a/wp-content/plugins/candela-license/candela-license.php
+++ b/wp-content/plugins/candela-license/candela-license.php
@@ -28,6 +28,7 @@ class CandelaLicense {
 
     add_action( 'add_meta_boxes', array( __CLASS__, 'add_meta_boxes' ) );
     add_action( 'save_post', array( __CLASS__, 'save') );
+    add_filter( 'pb_import_metakeys', array( __CLASS__, 'get_import_metakeys') );
   }
 
   /**
@@ -143,6 +144,14 @@ class CandelaLicense {
       $options[$option]['selected'] = (in_array($option, $selected) ? TRUE : FALSE);
     }
     return $options;
+  }
+  
+  /**
+   * Add Candela License to to-import meta 
+   */
+  public static function get_import_metakeys( $fields ) {
+  	$fields[] = CANDELA_LICENSE_FIELD; 
+  	return $fields; 
   }
 
   /**

--- a/wp-content/plugins/pressbooks/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/wp-content/plugins/pressbooks/includes/modules/import/wordpress/class-pb-wxr.php
@@ -120,11 +120,18 @@ class Wxr extends Import {
 
 			$pid = wp_insert_post( $new_post );
 
+			$meta_to_update = apply_filters( 'pb_import_metakeys', array('pb_section_author') );
+
 			if ( isset( $p['postmeta'] ) && is_array( $p['postmeta'] ) ) {
-				$section_author = $this->searchForSectionAuthor( $p['postmeta'] );
-				if ( $section_author ) {
-					update_post_meta( $pid, 'pb_section_author', $section_author );
-				}
+				foreach ($meta_to_update as $meta_key) {
+					$meta_val = $this->searchForMetaValue( $meta_key, $p['postmeta'] );
+					if ($meta_val) {
+						if (is_serialized($meta_val)) {
+							$meta_val = unserialize($meta_val);
+						}
+						update_post_meta( $pid, $meta_key, $meta_val );
+					}
+ 				}
 			}
 
 			update_post_meta( $pid, 'pb_show_title', 'on' );
@@ -168,11 +175,11 @@ class Wxr extends Import {
 	/**
 	 * Check for PB specific metadata, returns empty string if not found.
 	 *
-	 * @param array $postmeta
+	 * @param $meta_key, array $postmeta
 	 *
-	 * @return string Author's name
+	 * @return string meta field value
 	 */
-	protected function searchForSectionAuthor( array $postmeta ) {
+	protected function searchForMetaValue( $meta_key, array $postmeta ) {
 
 		if ( empty( $postmeta ) ) {
 			return '';
@@ -180,7 +187,7 @@ class Wxr extends Import {
 
 		foreach ( $postmeta as $meta ) {
 			// prefer this value, if it's set
-			if ( 'pb_section_author' == $meta['key'] ) {
+			if ( $meta_key == $meta['key'] ) {
 				return $meta['value'];
 			}
 		}


### PR DESCRIPTION
Per the request for more granular pull requests :)     (take 2)

This set of changes just adds import of Candela license and citation metadata on WRX import.

The approach has been rewritten to be much cleaner too. The class-pb-wrx file was modified to add a new filter hook for meta fields to update from import. The Candela citation and license plugins then use this new filter hook to register their meta fields for update on import.