### PR TITLE
Add whole-import citation and licensing

### DIFF
--- a/wp-content/plugins/candela-citation/candela-citation.php
+++ b/wp-content/plugins/candela-citation/candela-citation.php
@@ -39,6 +39,7 @@ class CandelaCitation {
       'chapter',
       'front-matter',
       'part',
+      'pb_import'
     );
   }
 
@@ -328,7 +329,17 @@ class CandelaCitation {
     $types = CandelaCitation::postTypes();
     $fields = CandelaCitation::citation_fields();
 
-    if ( isset( $_POST['post_type'] ) && in_array( $_POST['post_type'], $types ) ) {
+    $posttype = '';
+    if ( isset( $_POST['post_type'] ) ) {
+      $posttype = $_POST['post_type'];
+    } else {
+      $post = get_post( $post_id );
+      if ( !empty( $post->post_type ) ) {
+      	      $posttype = $post->post_type;
+      }
+    }
+ 
+    if ( $posttype != '' && in_array( $posttype, $types ) ) {
       // Use the first citation field to determine if citation fields were submitted.
       $key = key($fields);
 

--- a/wp-content/plugins/candela-license/candela-license.php
+++ b/wp-content/plugins/candela-license/candela-license.php
@@ -39,6 +39,7 @@ class CandelaLicense {
       'chapter',
       'front-matter',
       'part',
+      'pb_import'
     );
   }
 
@@ -61,7 +62,7 @@ class CandelaLicense {
     $license = get_post_meta( $post_id, CANDELA_LICENSE_FIELD, true);
     $options = CandelaLicense::GetOptions(array($license));
 
-    if (!empty($options[$license]['link'] && !empty($options[$license]['image'] ) ) ) {
+    if (!empty($options[$license]['link']) && !empty($options[$license]['image'] ) ) {
       echo '<a href="' . $options[$license]['link'] . ' rel="license"><img src="' . $options[$license]['image'] . '"></a>';
     }
     else {
@@ -164,7 +165,17 @@ class CandelaLicense {
 
     $licenses = array_keys(CandelaLicense::GetOptions());
 
-    if ( isset( $_POST['post_type'] ) && in_array( $_POST['post_type'], $types ) ) {
+    $posttype = '';
+    if ( isset( $_POST['post_type'] ) ) {
+      $posttype = $_POST['post_type'];
+    } else {
+      $post = get_post( $post_id );
+      if ( !empty( $post->post_type ) ) {
+      	      $posttype = $post->post_type;
+      }
+    }
+ 
+    if ( $posttype != '' && in_array( $posttype, $types ) ) {
       if ( isset( $_POST['candela-license'] ) && in_array($_POST['candela-license'], $licenses)) {
         update_post_meta( $post_id, CANDELA_LICENSE_FIELD, $_POST['candela-license']);
       }

--- a/wp-content/plugins/pressbooks/admin/templates/import.php
+++ b/wp-content/plugins/pressbooks/admin/templates/import.php
@@ -84,6 +84,13 @@ $current_import = get_option( 'pressbooks_current_import' );
 			</tbody>
 		</table>
 
+		<?php
+		do_action( 'add_meta_boxes', 'pb_import' );
+		$fake_post = new stdClass();
+		$fake_post->ID = 0;
+		do_meta_boxes( 'pb_import', 'normal', $fake_post );
+		?>
+
 		<p><?php
 			submit_button( __( 'Start', 'pressbooks' ), 'primary', 'submit', false );
 			echo " &nbsp; "; // Space


### PR DESCRIPTION
Again, per the request for more granular pull requests.

When importing an entire book from a single source, it would be convenient to be able to specify attribution and licensing once on the import page, rather than having to specify on every single page individually.

This change allows that by making minimal changes to the import.php template, adding a trigger to display meta boxes from plugins that register their add add_meta_boxes with the post_type "pb_import".

In the Candela plugins, some minor changes had to be made to the save() function to look up post_type, since post_type is not available in $_POST on import.