### PR TITLE
Import WRX, retaining part structure and content order

### DIFF
--- a/wp-content/plugins/pressbooks/admin/templates/import.php
+++ b/wp-content/plugins/pressbooks/admin/templates/import.php
@@ -58,6 +58,9 @@ $current_import = get_option( 'pressbooks_current_import' );
 				<th><?php _e( 'Title', 'pressbooks' ); ?></th>
 				<th style="width:10%;"><?php _e( 'Front Matter', 'pressbooks' ); ?></th>
 				<th style="width:10%;"><?php _e( 'Chapter', 'pressbooks' ); ?></th>
+				<?php if ( !empty( $current_import['allow_parts'] ) ) {?>
+				<th style="width:10%;"><?php _e( 'Part', 'pressbooks' ); ?></th>
+				<?php } ?>
 				<th style="width:10%;"><?php _e( 'Back Matter', 'pressbooks' ); ?></th>
 			</tr>
 			</thead>
@@ -73,9 +76,12 @@ $current_import = get_option( 'pressbooks_current_import' );
 				<tr <?php if ( $i % 2 ) echo 'class="alt"'; ?> >
 					<td><input type='checkbox' id='selective_import_<?php echo $i; ?>' name='chapters[<?php echo $key; ?>][import]' value='1'></td>
 					<td><label for="selective_import_<?php echo $i; ?>"><?php echo $chapter; ?></label></td>
-					<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='front-matter'></td>
-					<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='chapter' checked='checked'></td>
-					<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='back-matter'></td>
+					<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='front-matter' <?php checked(isset( $current_import['post_types'][$key] ) && 'front-matter' == $current_import['post_types'][$key]);?>></td>
+					<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='chapter' <?php checked(!isset( $current_import['post_types'][$key] ) || 'chapter' == $current_import['post_types'][$key]);?>></td>
+					<?php if ( !empty( $current_import['allow_parts'] ) ) {?>
+					<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='part' <?php checked(isset( $current_import['post_types'][$key] ) && 'part' == $current_import['post_types'][$key]);?>></td>
+					<?php } ?>
+					<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='back-matter' <?php checked(isset( $current_import['post_types'][$key] ) && 'back-matter' == $current_import['post_types'][$key]);?>></td>
 				</tr>
 				<?php
 				++$i;

--- a/wp-content/plugins/pressbooks/includes/modules/import/class-pb-import.php
+++ b/wp-content/plugins/pressbooks/includes/modules/import/class-pb-import.php
@@ -149,7 +149,7 @@ abstract class Import {
 	 */
 	protected function determinePostType( $id ) {
 
-		$supported_types = array( 'front-matter', 'chapter', 'back-matter' );
+		$supported_types = array( 'front-matter', 'chapter', 'part', 'back-matter' );
 		$default = 'chapter';
 
 		if ( ! @is_array( $_POST['chapters'] ) )

--- a/wp-content/plugins/pressbooks/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/wp-content/plugins/pressbooks/includes/modules/import/wordpress/class-pb-wxr.php
@@ -40,23 +40,27 @@ class Wxr extends Import {
 			'file_type' => $upload['type'],
 			'type_of' => 'wxr',
 			'chapters' => array(),
+			'post_types' => array(),
+			'allow_parts' => true
 		);
 
-		$supported_post_types = array( 'post', 'page', 'front-matter', 'chapter', 'back-matter' );
+		$supported_post_types = array( 'post', 'page', 'front-matter', 'chapter', 'part', 'back-matter' );
 
 		if ( $this->isPbWxr ) {
-			$xml['posts'] = \PressBooks\Utility\multi_sort( $xml['posts'], 'post_type:desc', 'post_parent:asc', 'menu_order:asc' );
+			//put the posts in correct part / menu_order order
+			$xml['posts'] = $this->customNestedSort( $xml['posts'] );
 		}
 
 		foreach ( $xml['posts'] as $p ) {
 
 			// Skip
 			if ( ! in_array( $p['post_type'], $supported_post_types ) ) continue;
-			if ( empty( $p['post_content'] ) ) continue;
+			if ( empty( $p['post_content'] ) && 'part' != $p['post_type'] ) continue;
 			if ( '<!-- Here be dragons.-->' == $p['post_content'] ) continue;
 
 			// Set
 			$option['chapters'][$p['post_id']] = $p['post_title'];
+			$option['post_types'][$p['post_id']] = $p['post_type'];
 		}
 
 		return update_option( 'pressbooks_current_import', $option );
@@ -79,6 +83,10 @@ class Wxr extends Import {
 
 		$this->pbCheck( $xml );
 
+		if ( $this->isPbWxr ) {
+			$xml['posts'] = $this->customNestedSort( $xml['posts'] );
+		}
+		
 		$match_ids = array_flip( array_keys( $current_import['chapters'] ) );
 		$chapter_parent = $this->getChapterParent();
 		$total = 0;
@@ -109,21 +117,34 @@ class Wxr extends Import {
 
 			$new_post = array(
 				'post_title' => wp_strip_all_tags( $p['post_title'] ),
-				'post_content' => $html,
 				'post_type' => $post_type,
-				'post_status' => 'draft',
+				'post_status' => ( 'part' == $post_type )?'publish':'draft',
 			);
+			
+			if ( 'part' != $post_type ) {
+				$new_post['post_content'] = $html;
+			}
 
 			if ( 'chapter' == $post_type ) {
 				$new_post['post_parent'] = $chapter_parent;
 			}
 
 			$pid = wp_insert_post( $new_post );
+			
+			if ( 'part' == $post_type ) {
+				$chapter_parent = $pid;
+			}
 
 			if ( isset( $p['postmeta'] ) && is_array( $p['postmeta'] ) ) {
 				$section_author = $this->searchForSectionAuthor( $p['postmeta'] );
 				if ( $section_author ) {
 					update_post_meta( $pid, 'pb_section_author', $section_author );
+				}
+				if ( 'part' == $post_type ) {
+					$part_content = $this->searchForPartContent( $p['postmeta'] );
+					if ( $part_content ) {
+						update_post_meta( $pid, 'pb_part_content', $part_content );
+					}
 				}
 			}
 
@@ -163,7 +184,49 @@ class Wxr extends Import {
 		}
 
 	}
-
+	
+	/**
+	 * Custom sort for the xml posts to put them in correct nested order
+	 *
+	 * @param array $xml
+	 *
+	 * @return array sorted $xml
+	 */
+	 protected function customNestedSort( $xml ) {
+	 	 $array = array();
+	 	 
+	 	 //first, put them in ascending menu_order
+	 	 usort($xml, function ($a, $b) {
+	 	 	return ($a['menu_order'] - $b['menu_order']);
+	 	 });
+	 	 
+	 	 //now, list all front matter
+	 	 foreach ( $xml as $p ) {
+	 	 	if ('front-matter' == $p['post_type']) {
+	 	 		$array[] = $p;	
+	 	 	}
+	 	 }
+	 	 
+	 	 //now, list all parts, then their associated chapters
+	 	 foreach ( $xml as $p ) {
+	 	 	if ('part' == $p['post_type']) {
+	 	 		$array[] = $p;
+	 	 		foreach ($xml as $psub) {
+	 	 			if ('chapter' == $psub['post_type'] && $psub['post_parent'] == $p['post_id']) {
+	 	 				$array[] = $psub;
+	 	 			}
+	 	 		}
+	 	 	}
+	 	 }
+	 	 
+	 	 //now, list all back matter
+	 	 foreach ( $xml as $p ) {
+	 	 	if ('back-matter' == $p['post_type']) {
+	 	 		$array[] = $p;	
+	 	 	}
+	 	 }
+	 	 return $array;
+	 }
 
 	/**
 	 * Check for PB specific metadata, returns empty string if not found.
@@ -188,7 +251,29 @@ class Wxr extends Import {
 		return '';
 	}
 
+	/**
+	 * Check for PB specific metadata, returns empty string if not found.
+	 *
+	 * @param array $postmeta
+	 *
+	 * @return string Part Content
+	 */
+	protected function searchForPartContent( array $postmeta ) {
 
+		if ( empty( $postmeta ) ) {
+			return '';
+		}
+
+		foreach ( $postmeta as $meta ) {
+			// prefer this value, if it's set
+			if ( 'pb_part_content' == $meta['key'] ) {
+				return $meta['value'];
+			}
+		}
+
+		return '';
+	}
+	
 	/**
 	 * Parse HTML snippet, save all found <img> tags using media_handle_sideload(), return the HTML with changed <img> paths.
 	 *


### PR DESCRIPTION
Last one for today, I promise :)

Currently when a Pressbooks export is re-imported, 1) the content comes loaded in content order, rather than sorted display order, 2) any part structure that was created is lost, and 3) any part text is lost.

This is one possible way to address this, so a Pressbooks export can be re-imported retaining all the original structure and ordering.

First, the order of content on the import selection page and during import is put in proper display order based on the Part structure and post menu_order. The post type radios are automatically selected for PressBooks imports based on their original export type.

For WRX imports, a new column is added on the import page for Parts, allowing an item to be imported as a Part. During import, when an item is imported as a Part, it becomes the parent Part for any chapters that follow it in the import, until a new Part is imported. Any chapters imported before the first Part get assigned to the first available Part, as is the current default.
