### PR TITLE
Add MyOpenMath mimetex as a pb-latex rendering option

### DIFF
--- a/wp-content/plugins/pressbooks/symbionts/pb-latex/automattic-latex-momcom.php
+++ b/wp-content/plugins/pressbooks/symbionts/pb-latex/automattic-latex-momcom.php
@@ -44,8 +44,13 @@ class Automattic_Latex_MOMCOM {
 	function wrapper( $wrapper = false ) {}
 
 	function url() {
+		//mimetex doesn't like hfill
+		$tex = str_replace( '\hfill', '', $this->latex );
+		$encoded = rawurlencode( $tex );
+		//workaround weird encoding issue
+		$encoded = str_replace( '%C2%20', '%20', $encoded);
 		//$this->url = 'http://s.wordpress.com/latex.php?latex=' . rawurlencode( $this->latex ) . "&bg=$this->bg_hex&fg=$this->fg_hex&s=$this->size";
-		$this->url = 'https://www.myopenmath.com/cgi-bin/mimetex.cgi?' . rawurlencode( $this->latex );
+		$this->url = 'https://www.myopenmath.com/cgi-bin/mimetex.cgi?' . $encoded;
 		return $this->url;
 	}
 }

--- a/wp-content/plugins/pressbooks/symbionts/pb-latex/automattic-latex-momcom.php
+++ b/wp-content/plugins/pressbooks/symbionts/pb-latex/automattic-latex-momcom.php
@@ -1,0 +1,51 @@
+<?php
+/*
+Version: 1.1
+Copyright: Automattic, Inc.
+License: GPL2+
+*/
+
+class Automattic_Latex_MOMCOM {
+	var $latex;
+	var $bg_hex;
+	var $fg_hex;
+	var $size;
+	var $zoom = 1;
+
+	var $url;
+
+	var $error;
+
+	function __construct( $latex, $bg_hex = 'ffffff', $fg_hex = '000000', $size = 0 ) {
+		$this->latex  = (string) $latex;
+		//$this->bg_hex = $this->sanitize_hex( $bg_hex );
+		//$this->fg_hex = $this->sanitize_hex( $fg_hex );
+		//$this->size   = (int) $size;
+	}
+
+	function set_zoom( $zoom ) {
+		$this->zoom = $zoom;
+	}
+
+	function sanitize_hex( $color ) {
+		if ( 'transparent' == $color )
+			return 'T';
+
+		// Fix for 3 letter hex codes
+		if ( 3 == strlen( $color ) )
+			$color = $color[0] . $color[0] . $color[1] . $color[1]. $color[2] . $color[2];
+
+		$color = substr( preg_replace( '/[^0-9a-f]/i', '', (string) $color ), 0, 6 );
+		if ( 6 > $l = strlen( $color ) )
+			$color .= str_repeat('0', 6 - $l );
+		return $color;
+	}
+
+	function wrapper( $wrapper = false ) {}
+
+	function url() {
+		//$this->url = 'http://s.wordpress.com/latex.php?latex=' . rawurlencode( $this->latex ) . "&bg=$this->bg_hex&fg=$this->fg_hex&s=$this->size";
+		$this->url = 'https://www.myopenmath.com/cgi-bin/mimetex.cgi?' . rawurlencode( $this->latex );
+		return $this->url;
+	}
+}

--- a/wp-content/plugins/pressbooks/symbionts/pb-latex/pb-latex-admin.php
+++ b/wp-content/plugins/pressbooks/symbionts/pb-latex/pb-latex-admin.php
@@ -244,6 +244,7 @@ tr.pb-latex-method-<?php echo $current_method; ?> {
 			<td>
 				<ul id="pb-latex-method-switch">
 					<li><label for="pb-latex-method-wpcom"><input type="radio" name="pb_latex[method]" id="pb-latex-method-wpcom" value='Automattic_Latex_WPCOM'<?php checked( 'Automattic_Latex_WPCOM', $values['method'] ); ?> /> <?php printf( _x( '%s LaTeX server (recommended)|WordPress.com LaTeX Server (recommended)', 'pb-latex' ), '<a href="http://wordpress.com/" target="_blank">WordPress.com</a>' ); ?></label></li>
+					<li><label for="pb-latex-method-momcom"><input type="radio" name="pb_latex[method]" id="pb-latex-method-momcom" value='Automattic_Latex_MOMCOM'<?php checked( 'Automattic_Latex_MOMCOM', $values['method'] ); ?> /> <?php printf( _x( '%s MimeTeX server', 'pb-latex' ), 'MyOpenMath.com' ); ?></label></li>
 				</ul>
 			</td>
 		</tr>
@@ -264,7 +265,7 @@ tr.pb-latex-method-<?php echo $current_method; ?> {
 			</td>
 		</tr>
 		
-	<?php foreach ( $default_wrappers as $method => $default_wrapper ) : ?>
+	<?php /*foreach ( $default_wrappers as $method => $default_wrapper ) : ?>
 		<tr class="pb-latex-method pb-latex-method-<?php echo $method; ?>">
 			<th></th>
 			<td>
@@ -272,7 +273,7 @@ tr.pb-latex-method-<?php echo $current_method; ?> {
 				<div class="pre"><code><?php echo $default_wrapper; ?></code></div>
 			</td>
 		</tr>
-	<?php endforeach; ?>
+	<?php endforeach; */?>
 	</tbody>
 	</table>
 	

--- a/wp-content/plugins/pressbooks/symbionts/pb-latex/pb-latex.php
+++ b/wp-content/plugins/pressbooks/symbionts/pb-latex/pb-latex.php
@@ -26,6 +26,7 @@ class PBLatex {
 	var $options;
 	var $methods = array(
 	    'Automattic_Latex_WPCOM' => 'wpcom',
+	    'Automattic_Latex_MOMCOM' => 'momcom'
 	);
 
 	function init() {


### PR DESCRIPTION
This change adds the MyOpenMath mimetex server to the list of rendering options for pb-latex.  Mimetex provides support for \cancel, needed for some content.