### PR TITLE
remove the TOC from the sidebar in all themes

### DIFF
--- a/wp-content/plugins/candela-utility/themes/candela-advanced/sidebar.php
+++ b/wp-content/plugins/candela-utility/themes/candela-advanced/sidebar.php
@@ -1,0 +1,16 @@
+<?php global $blog_id; ?>
+	<?php if (get_option('blog_public') == '1' || (get_option('blog_public') == '0' && current_user_can_for_blog($blog_id, 'read'))): ?>
+
+	<div id="sidebar">
+
+		<ul id="booknav">
+		<!-- If Logged in show ADMIN -->
+			<?php global $blog_id; ?>
+			<?php if (current_user_can_for_blog($blog_id, 'edit_posts') || is_super_admin()): ?>
+				<li class="admin-btn"><a href="<?php echo get_option('home'); ?>/wp-admin/admin.php?page=pressbooks"><?php _e('Admin', 'pressbooks'); ?></a></li>
+			<?php endif; ?>
+				<li class="home-btn"><a href="<?php echo get_option('home'); ?>"><?php _e('Home', 'pressbooks'); ?></a></li>
+    </ul>
+
+	</div><!-- end #sidebar -->
+	<?php endif; ?>

--- a/wp-content/plugins/candela-utility/themes/candela/sidebar.php
+++ b/wp-content/plugins/candela-utility/themes/candela/sidebar.php
@@ -1,0 +1,16 @@
+<?php global $blog_id; ?>
+	<?php if (get_option('blog_public') == '1' || (get_option('blog_public') == '0' && current_user_can_for_blog($blog_id, 'read'))): ?>
+
+	<div id="sidebar">
+
+		<ul id="booknav">
+		<!-- If Logged in show ADMIN -->
+			<?php global $blog_id; ?>
+			<?php if (current_user_can_for_blog($blog_id, 'edit_posts') || is_super_admin()): ?>
+				<li class="admin-btn"><a href="<?php echo get_option('home'); ?>/wp-admin/admin.php?page=pressbooks"><?php _e('Admin', 'pressbooks'); ?></a></li>
+			<?php endif; ?>
+				<li class="home-btn"><a href="<?php echo get_option('home'); ?>"><?php _e('Home', 'pressbooks'); ?></a></li>
+    </ul>
+
+	</div><!-- end #sidebar -->
+	<?php endif; ?>

--- a/wp-content/plugins/candela-utility/themes/washington/sidebar.php
+++ b/wp-content/plugins/candela-utility/themes/washington/sidebar.php
@@ -1,0 +1,16 @@
+<?php global $blog_id; ?>
+	<?php if (get_option('blog_public') == '1' || (get_option('blog_public') == '0' && current_user_can_for_blog($blog_id, 'read'))): ?>
+
+	<div id="sidebar">
+
+		<ul id="booknav">
+		<!-- If Logged in show ADMIN -->
+			<?php global $blog_id; ?>
+			<?php if (current_user_can_for_blog($blog_id, 'edit_posts') || is_super_admin()): ?>
+				<li class="admin-btn"><a href="<?php echo get_option('home'); ?>/wp-admin/admin.php?page=pressbooks"><?php _e('Admin', 'pressbooks'); ?></a></li>
+			<?php endif; ?>
+				<li class="home-btn"><a href="<?php echo get_option('home'); ?>"><?php _e('Home', 'pressbooks'); ?></a></li>
+    </ul>
+
+	</div><!-- end #sidebar -->
+	<?php endif; ?>


### PR DESCRIPTION
the TOC causes performance problems for large books,
so removing for now.

Test Plan:
 * For candela, candela advanced, and washington themes:
 * Load a content page, the TOC should not be on the right sidebar