### PR TITLE
A fix for stripped backslashes in IMSCC imports

### DIFF
--- a/wp-content/plugins/pressbooks/includes/modules/import/imscc/class-pb-imscc.php
+++ b/wp-content/plugins/pressbooks/includes/modules/import/imscc/class-pb-imscc.php
@@ -59,7 +59,7 @@ class IMSCC extends Import {
           $new_post['post_parent'] = $this->getChapterParent();
         }
 
-        $pid = wp_insert_post( $new_post );
+        $pid = wp_insert_post( add_magic_quotes( $new_post ) );
 
         // @todo postmeta like author
 


### PR DESCRIPTION
Uses the same approach utilized by Pressbooks in fixing the same issue in imports for other formats (Pressbooks issue [#79/#116](https://github.com/pressbooks/pressbooks/pull/116))