### PR TITLE
improve line spacing on h2 and h3 in content for bombadil theme

### DIFF
--- a/wp-content/plugins/candela-utility/themes/bombadil/style.css
+++ b/wp-content/plugins/candela-utility/themes/bombadil/style.css
@@ -757,13 +757,15 @@ div#wrap {
 }
 #content h2 {
 	font-size: 1.25em;
+  margin-top: 1.5em;
 	margin-bottom: 1em;
   text-transform: uppercase;
 }
 #content h3 {
 	font-size: 1em;
 	text-transform: uppercase;
-	margin-top: 1em;
+  margin-top: 1.75em;
+	margin-bottom: 1.25em;
 	text-align: left;
   color: #6c64ad;
 }


### PR DESCRIPTION
add margin top and bottom to h2 and h3 inside #content using ems instead of px for relative spacing and reading ease