### PR TITLE
Updating links for Public Domain and CC0 marks

### DIFF
--- a/wp-content/plugins/candela-citation/candela-citation.php
+++ b/wp-content/plugins/candela-citation/candela-citation.php
@@ -314,11 +314,11 @@ class CandelaCitation {
         $options = array(
           'pd' =>  array(
             'label' => __( 'Public Domain: No Known Copyright' ),
-            'link' => 'https://creativecommons.org/about/pdm',
+            'link' => 'https://creativecommons.org/publicdomain/mark/1.0/',
           ),
           'cc0' => array(
             'label' => __( 'CC0: No Rights Reserved' ),
-            'link' => 'https://creativecommons.org/about/cc0',
+            'link' => 'https://creativecommons.org/publicdomain/zero/1.0/',
           ),
           'cc-by' => array(
             'label' => __( 'CC BY: Attribution' ),


### PR DESCRIPTION
As per Creative Commons' feedback, changing these links so they point at the Deed pages instead of the About pages.
