### PR TITLE
search field bug fix (firefox)

### DIFF
--- a/wp-content/plugins/candela-utility/themes/bombadil/style.css
+++ b/wp-content/plugins/candela-utility/themes/bombadil/style.css
@@ -427,6 +427,7 @@ nav {
   height: 24px;
   display: inline-block;
   vertical-align: bottom;
+  padding: 0 0.5rem 0 0.5rem;
 }
 .searchform #searchsubmit {
   position: absolute;


### PR DESCRIPTION
fix bug (only witnessed in firefox) that was cutting off part of the text in the search field of the bombadil theme.