### PR TITLE
embeddable iframes

### DIFF
--- a/wp-content/plugins/candela-utility/themes/bombadil/functions.php
+++ b/wp-content/plugins/candela-utility/themes/bombadil/functions.php
@@ -126,23 +126,28 @@ function add_iframe_resize_message() {
 
 }
 
-// allow script & iframe tag within posts
+// allow iframe tag within posts
 function allow_post_tags( $allowedposttags ){
-    $allowedposttags['script'] = array(
-        'type' => true,
-        'src' => true,
-        'height' => true,
-        'width' => true,
-    );
     $allowedposttags['iframe'] = array(
-        'src' => true,
-        'width' => true,
-        'height' => true,
+        'align' => true,
+        'allowFullScreen' => true,
         'class' => true,
         'frameborder' => true,
-        'webkitAllowFullScreen' => true,
+        'height' => true,
+        'id' => true,
+        'longdesc' => true,
+        'marginheight' => true,
+        'marginwidth' => true,
         'mozallowfullscreen' => true,
-        'allowFullScreen' => true
+        'name' => true,
+        'sandbox' => true,
+        'seamless' => true,
+        'scrolling' => true,
+        'src' => true,
+        'srcdoc' => true,
+        'style' => true,
+        'width' => true,
+        'webkitAllowFullScreen' => true
     );
     return $allowedposttags;
 }

--- a/wp-content/plugins/candela-utility/themes/bombadil/functions.php
+++ b/wp-content/plugins/candela-utility/themes/bombadil/functions.php
@@ -125,3 +125,25 @@ function add_iframe_resize_message() {
   );
 
 }
+
+// allow script & iframe tag within posts
+function allow_post_tags( $allowedposttags ){
+    $allowedposttags['script'] = array(
+        'type' => true,
+        'src' => true,
+        'height' => true,
+        'width' => true,
+    );
+    $allowedposttags['iframe'] = array(
+        'src' => true,
+        'width' => true,
+        'height' => true,
+        'class' => true,
+        'frameborder' => true,
+        'webkitAllowFullScreen' => true,
+        'mozallowfullscreen' => true,
+        'allowFullScreen' => true
+    );
+    return $allowedposttags;
+}
+add_filter('wp_kses_allowed_html','allow_post_tags', 1);

--- a/wp-content/plugins/candela-utility/themes/candela/functions.php
+++ b/wp-content/plugins/candela-utility/themes/candela/functions.php
@@ -93,3 +93,25 @@ function add_iframe_resize_message() {
   );
 
 }
+
+// allow script & iframe tag within posts
+function allow_post_tags( $allowedposttags ){
+    $allowedposttags['script'] = array(
+        'type' => true,
+        'src' => true,
+        'height' => true,
+        'width' => true,
+    );
+    $allowedposttags['iframe'] = array(
+        'src' => true,
+        'width' => true,
+        'height' => true,
+        'class' => true,
+        'frameborder' => true,
+        'webkitAllowFullScreen' => true,
+        'mozallowfullscreen' => true,
+        'allowFullScreen' => true
+    );
+    return $allowedposttags;
+}
+add_filter('wp_kses_allowed_html','allow_post_tags', 1);

--- a/wp-content/plugins/candela-utility/themes/candela/functions.php
+++ b/wp-content/plugins/candela-utility/themes/candela/functions.php
@@ -94,23 +94,28 @@ function add_iframe_resize_message() {
 
 }
 
-// allow script & iframe tag within posts
+// allow iframe tag within posts
 function allow_post_tags( $allowedposttags ){
-    $allowedposttags['script'] = array(
-        'type' => true,
-        'src' => true,
-        'height' => true,
-        'width' => true,
-    );
     $allowedposttags['iframe'] = array(
-        'src' => true,
-        'width' => true,
-        'height' => true,
+        'align' => true,
+        'allowFullScreen' => true,
         'class' => true,
         'frameborder' => true,
-        'webkitAllowFullScreen' => true,
+        'height' => true,
+        'id' => true,
+        'longdesc' => true,
+        'marginheight' => true,
+        'marginwidth' => true,
         'mozallowfullscreen' => true,
-        'allowFullScreen' => true
+        'name' => true,
+        'sandbox' => true,
+        'seamless' => true,
+        'scrolling' => true,
+        'src' => true,
+        'srcdoc' => true,
+        'style' => true,
+        'width' => true,
+        'webkitAllowFullScreen' => true
     );
     return $allowedposttags;
 }

--- a/wp-content/plugins/candela-utility/themes/washington/functions.php
+++ b/wp-content/plugins/candela-utility/themes/washington/functions.php
@@ -124,3 +124,30 @@ function add_iframe_resize_message() {
   );
 
 }
+
+// allow iframe tag within posts
+function allow_post_tags( $allowedposttags ){
+    $allowedposttags['iframe'] = array(
+        'align' => true,
+        'allowFullScreen' => true,
+        'class' => true,
+        'frameborder' => true,
+        'height' => true,
+        'id' => true,
+        'longdesc' => true,
+        'marginheight' => true,
+        'marginwidth' => true,
+        'mozallowfullscreen' => true,
+        'name' => true,
+        'sandbox' => true,
+        'seamless' => true,
+        'scrolling' => true,
+        'src' => true,
+        'srcdoc' => true,
+        'style' => true,
+        'width' => true,
+        'webkitAllowFullScreen' => true
+    );
+    return $allowedposttags;
+}
+add_filter('wp_kses_allowed_html','allow_post_tags', 1);


### PR DESCRIPTION
Implement ability to embed iframes in candela pages (excluding the ability to embed script tags) and protect iframe attributes from being stripped by TinyMCE in Wordpress.