### PR TITLE
fix for mPDF export functionality

### DIFF
--- a/wp-content/plugins/pressbooks/templates/admin/export.php
+++ b/wp-content/plugins/pressbooks/templates/admin/export.php
@@ -12,9 +12,9 @@ if ( ! defined( 'ABSPATH' ) )
 $max_batches = 5; // How many batches we save
 \PressBooks\Utility\truncate_exports( $max_batches );
 
-$export_form_url = wp_nonce_url( get_bloginfo( 'url' ) . '/wp-admin/admin.php?page=pb_export&export=yes', 'pb-export' );
-$export_delete_url = wp_nonce_url( get_bloginfo( 'url' ) . '/wp-admin/admin.php?page=pb_export', 'pb-delete-export' );
-$download_url_prefix = get_bloginfo( 'url' ) . '/wp-admin/admin.php?page=pb_export&download_export_file=';
+$export_form_url = wp_nonce_url( get_admin_url( get_current_blog_id(), '/admin.php?page=pb_export&export=yes' ), 'pb-export' );
+$export_delete_url = wp_nonce_url( get_admin_url( get_current_blog_id(), '/admin.php?page=pb_export' ), 'pb-delete-export' );
+$download_url_prefix = get_admin_url( get_current_blog_id(), '/admin.php?page=pb_export&download_export_file=' );
 
 date_default_timezone_set( 'America/Montreal' );
 


### PR DESCRIPTION
Not knowing the workflow for how PB is updated within the candela stack, this PR risks interfering with that so feel free to disregard or make suggestions, though it resolves not being able to export mPDF (at least for me) and is consistent with where PB has gone: https://github.com/pressbooks/pressbooks/blob/dev/templates/admin/export.php#L15